### PR TITLE
Update api.py

### DIFF
--- a/docker/fish-speech/api.py
+++ b/docker/fish-speech/api.py
@@ -56,7 +56,7 @@ pyrootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 from fish_speech.models.vqgan.modules.firefly import FireflyArchitecture
 from fish_speech.text.chn_text_norm.text import Text as ChnNormedText
 from fish_speech.utils import autocast_exclude_mps
-from tools.commons import ServeReferenceAudio, ServeTTSRequest
+from tools.schema import ServeReferenceAudio, ServeTTSRequest
 from tools.file import AUDIO_EXTENSIONS, audio_to_bytes, list_files, read_ref_text
 from tools.llama.generate import (
     GenerateRequest,


### PR DESCRIPTION
The current import is broken, according to the latest `fish-speech` repo the `common` imports are under `tools.schema` as you can see in [their repo](https://github.com/fishaudio/fish-speech/blob/main/tools/schema.py). This discrepancy is due to the use of their latest image version `FROM fishaudio/fish-speech:latest-dev` when running `docker-compose build`.